### PR TITLE
Remove dependency on utf8::all (hence perl-5.10)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,2 +1,5 @@
+0.02 - Thu Dec 25 13:19:31 CST 2014
+	* Remove dependency on utf8::all (hence perl-5.10)
+
 0.01 - Tue Feb 26 01:18:51 CET 2013
 	* initial beta release

--- a/dist.ini
+++ b/dist.ini
@@ -8,8 +8,6 @@ copyright_holder = Rodrigo de Oliveira
 [@Classic]
 
 [MetaJSON]
-[Prereqs]
-utf8::all      = 0
 
 [MetaResources]
 repository = git://github.com/rodrigolive/getopt-mini.git
@@ -31,13 +29,13 @@ homepage = http://search.cpan.org/perldoc?Getopt-Mini
     stopwords = stopwords
     stopwords = wordlist
 
-[Homepage] 
+[Homepage]
 [Repository]
 [MinimumPerl]
 [NextRelease]
 time_zone = UTC
 filename = Changes
-[Prepender] 
+[Prepender]
 copyright = 1
 author = 1
 [PodWeaver]


### PR DESCRIPTION
Use Encode instead. This makes this module usable on perl-5.8.

Resolves issue #1
